### PR TITLE
silence amqp/stevedore loggers by default

### DIFF
--- a/xivo_test_helpers/asset_launching_test_case.py
+++ b/xivo_test_helpers/asset_launching_test_case.py
@@ -16,8 +16,10 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 if os.environ.get('TEST_LOGS') != 'verbose':
-    logging.getLogger('urllib3.connectionpool').setLevel(logging.WARNING)
+    logging.getLogger('amqp').setLevel(logging.INFO)
     logging.getLogger('docker').setLevel(logging.INFO)
+    logging.getLogger('stevedore.extension').setLevel(logging.INFO)
+    logging.getLogger('urllib3.connectionpool').setLevel(logging.WARNING)
     logger.setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
reason: amqp is too verbose with heartbeat
stevedore: too verbose each time we initialize client