### PR TITLE
wazo-auth-mock: return 204 when validating wrong acl token without scope

### DIFF
--- a/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
+++ b/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
@@ -290,7 +290,10 @@ def add_valid_credentials():
 
 @app.route(url_prefix + "/0.1/token/<token>", methods=['HEAD'])
 def token_head_ok(token):
+    required_acl = request.args.get('scope')
     if token in wrong_acl_tokens:
+        if not required_acl:
+            return '', 204
         return '', 403
     elif token in valid_tokens:
         if _valid_acl(token):


### PR DESCRIPTION
Why:

* When a daemon is missing required_acl decorator, it will validate the
token without scope.
* In this case, the wazo-auth mock should behave like wazo-auth and
return 204.
* It should only return 403 when the client asks for a scope.