### PR TITLE
stop to use deprecated --no-ansi option with docker-compose

### DIFF
--- a/xivo_test_helpers/asset_launching_test_case.py
+++ b/xivo_test_helpers/asset_launching_test_case.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -262,7 +262,7 @@ class AssetLaunchingTestCase(unittest.TestCase):
     @classmethod
     def _docker_compose_options(cls):
         options = [
-            '--no-ansi',
+            '--ansi', 'never',
             '--project-name', cls.service,
             '--file', os.path.join(cls.assets_root, 'docker-compose.yml'),
             '--file', os.path.join(


### PR DESCRIPTION
Remove annoying deprecated warning
```
--no-ansi option is deprecated and will be removed in future versions.
```
Warning: it will probably fail in all environment without the last docker-compose version
Post-merge: inform all devs