### PR TITLE
raises: show the traceback of the actual error

### DIFF
--- a/xivo_test_helpers/hamcrest/raises.py
+++ b/xivo_test_helpers/hamcrest/raises.py
@@ -1,13 +1,16 @@
 # Copyright 2011 hamcrest.org
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright 2017-2020 The Wazo Authors  (see AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Derived from https://github.com/hamcrest/PyHamcrest/blob/master/src/hamcrest/core/core/raises.py
 
 from weakref import ref
+
 import sys
+import traceback
+
 from hamcrest.core.base_matcher import BaseMatcher
 
 __author__ = "Per Fagrell"
@@ -68,7 +71,10 @@ class Raises(BaseMatcher):
                        .append_text(' because ')
             self.matcher.describe_mismatch(self.actual, description)
         else:
-            description.append_text('%s was raised instead: %s' % (type(self.actual), str(self.actual)))
+            description.append_text('%s was raised instead: %s\n' % (type(self.actual), str(self.actual)))
+            traceback_lines = traceback.format_exception(type(self.actual), self.actual, self.actual.__traceback__)
+            for traceback_line in traceback_lines:
+                description.append_text(traceback_line)
 
 
 def raises(exception, matcher=None):


### PR DESCRIPTION
Why:

* Easier to find the source of the error