### PR TITLE
service mocks: limit memory size

### DIFF
--- a/contribs/docker/wazo-amid-mock/mock-wazo-amid.py
+++ b/contribs/docker/wazo-amid-mock/mock-wazo-amid.py
@@ -7,6 +7,7 @@ import json
 import logging
 import sys
 
+from collections import deque
 from flask import Flask
 from flask import jsonify
 from flask import request
@@ -17,7 +18,7 @@ logging.basicConfig(level=logging.DEBUG)
 app = Flask(__name__)
 logger = logging.getLogger('amid-mock')
 
-_requests = []
+_requests = deque(maxlen=1024)
 _responses = {'action': {'DeviceStateList': [], 'CoreShowChannels': [], 'Command': {'response': ['Success']}}}
 
 

--- a/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
+++ b/contribs/docker/wazo-auth-mock/wazo-auth-mock.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import uuid
 
+from collections import deque
 from flask import Flask, jsonify, request
 
 logging.basicConfig(level=logging.DEBUG)
@@ -120,7 +121,7 @@ token_that_will_be_invalid_when_used = [('test', 'iddqd')]
 users = {}
 wrong_acl_tokens = {'invalid-acl-token'}
 
-_requests = []
+_requests = deque(maxlen=1024)
 
 
 def _reset():

--- a/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
+++ b/contribs/docker/wazo-confd-mock/mock-wazo-confd.py
@@ -7,6 +7,7 @@ import json
 import logging
 import sys
 
+from collections import deque
 from flask import Flask
 from flask import jsonify
 from flask import request
@@ -40,7 +41,7 @@ _EMPTY_RESPONSES = {
 app = Flask(__name__)
 logger = logging.getLogger('confd-mock')
 
-_requests = []
+_requests = deque(maxlen=1024)
 _responses = {}
 
 

--- a/contribs/docker/wazo-sysconfd-mock/wazo-sysconfd-mock.py
+++ b/contribs/docker/wazo-sysconfd-mock/wazo-sysconfd-mock.py
@@ -1,15 +1,16 @@
 #!/usr/bin/python2
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import sys
 
+from collections import deque
 from flask import Flask, request, jsonify
 
 app = Flask(__name__)
 port = sys.argv[1]
 
-REQUESTS = []
+REQUESTS = deque(maxlen=1024)
 
 
 @app.before_request


### PR DESCRIPTION
Why:

* When receiving many requests, the list of requests stored can take a
lot of memory.

How:

* Set a maximum size to the list of request via deque()