### PR TITLE
asset launching: reduce timeout

### DIFF
--- a/xivo_test_helpers/asset_launching_test_case.py
+++ b/xivo_test_helpers/asset_launching_test_case.py
@@ -282,7 +282,7 @@ class AssetLaunchingTestCase(unittest.TestCase):
     @classmethod
     def _container_id(cls, service_name):
         result = _run_cmd(['docker-compose'] + cls._docker_compose_options() +
-                          ['ps', '-q', service_name], stderr=False, timeout=5).stdout.strip()
+                          ['ps', '-q', service_name], stderr=False, timeout=1).stdout.strip()
         result = result.decode('utf-8')
         if '\n' in result:
             raise AssertionError('There is more than one container running with name {}'.format(service_name))


### PR DESCRIPTION
Why:

* wazo-confd integration tests are failing with memory error when
getting the container id