### PR TITLE
asset launching: increase timeout for container ID

### DIFF
--- a/xivo_test_helpers/asset_launching_test_case.py
+++ b/xivo_test_helpers/asset_launching_test_case.py
@@ -282,7 +282,7 @@ class AssetLaunchingTestCase(unittest.TestCase):
     @classmethod
     def _container_id(cls, service_name):
         result = _run_cmd(['docker-compose'] + cls._docker_compose_options() +
-                          ['ps', '-q', service_name], stderr=False, timeout=1).stdout.strip()
+                          ['ps', '-q', service_name], stderr=False, timeout=3).stdout.strip()
         result = result.decode('utf-8')
         if '\n' in result:
             raise AssertionError('There is more than one container running with name {}'.format(service_name))


### PR DESCRIPTION
Why:

* 1 second is too short and makes correct tests fail