### PR TITLE
Bump mypy pre-commit hook to v1.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.19.1
     hooks:
       - id: mypy
         language_version: "3.11"

--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -88,7 +88,7 @@ class ContainerCommandFailed(Exception):
         super().__init__(message)
 
 
-class CachedClassProperty(Generic[R]):
+class CachedClassProperty(Generic[ClassType, R]):
     __slots__ = ('_func', '_value')
 
     def __init__(self, func: Callable[[ClassType], R]) -> None:
@@ -191,8 +191,8 @@ class AbstractAssetLaunchingHelper:
             std_output = completed_process.stdout
             err_output = completed_process.stderr
             raise ContainerStartFailed(
-                stdout=std_output.decode('unicode-escape') if std_output else None,
-                stderr=err_output.decode('unicode-escape') if err_output else None,
+                stdout=std_output.decode('unicode-escape') if std_output else '',
+                stderr=err_output.decode('unicode-escape') if err_output else '',
                 return_code=completed_process.returncode,
             )
 
@@ -210,8 +210,8 @@ class AbstractAssetLaunchingHelper:
             stdout = completed_process.stdout
             stderr = completed_process.stderr
             raise ContainerStartFailed(
-                stdout=stdout.decode('unicode-escape') if stdout else None,
-                stderr=stderr.decode('unicode-escape') if stderr else None,
+                stdout=stdout.decode('unicode-escape') if stdout else '',
+                stderr=stderr.decode('unicode-escape') if stderr else '',
                 return_code=completed_process.returncode,
             )
 


### PR DESCRIPTION
Fix type errors revealed by new mypy version:
- Make CachedClassProperty generic over ClassType to fix TypeVar scope
- Use empty string instead of None for ContainerStartFailed args

Resolves compatibility issues with latest types-setuptools.
See WAZO-4386.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Update tooling**: Bump `mypy` pre-commit hook to `v1.19.1` in `.pre-commit-config.yaml`.
> - **Typing fix**: Make `CachedClassProperty` generic over `ClassType` and adjust descriptor annotations in `wazo_test_helpers/asset_launching_test_case.py`.
> - **Error handling**: When raising `ContainerStartFailed` from `run_container`/`start_containers`, pass decoded `stdout`/`stderr` as `''` instead of `None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 607e597f55016857ce6088351bfd0daeacaa2855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->