### PR TITLE
asset_launching: allow overriding docker-compose project name

### DIFF
--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -133,6 +133,10 @@ class AbstractAssetLaunchingHelper:
     asset: str  # The name of the asset to run, e.g 'base'
     assets_root: str | Path  # Root path for storing assets
 
+    # Prefix for the docker-compose project name, distinguishing this suite's
+    # containers from others using the same `service` name. Defaults to `service`.
+    project_name: str | None = None
+
     cur_dir: str | Path | None = None
     log_dir: str | Path | None = None
 
@@ -452,7 +456,7 @@ class AbstractAssetLaunchingHelper:
             '--ansi',
             'never',
             '--project-name',
-            cls.service + '_' + cls.asset,
+            (cls.project_name or cls.service) + '_' + cls.asset,
             '--file',
             str(root_dir / 'docker-compose.yml'),
             '--file',


### PR DESCRIPTION
## Summary
- Add an optional `project_name` class attribute to `AbstractAssetLaunchingHelper`, used as the docker-compose project-name prefix instead of `service`.
- Defaults to `None`, in which case `_docker_compose_options()` falls back to `service` — fully backward compatible with existing subclasses.

This lets suites whose `service` name collides with another suite's (e.g. two different repos both testing a service named "auth") pick a distinct docker-compose project name, without needing to override `_docker_compose_options()` themselves.

## Test plan
- [x] `pre-commit run --all-files` (flake8, black, mypy, pyupgrade, isort, copyright check) passes
- [ ] wazo-nestbox-plugin's integration test suite (currently working around this via a local `_docker_compose_options()` override) switches to the new `project_name` attribute once this is merged, confirming the override point works end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible test-infra change that only affects docker-compose project naming when explicitly set.
> 
> **Overview**
> Adds an optional **`project_name`** class attribute on `AbstractAssetLaunchingHelper` so integration suites can choose the docker-compose **`--project-name`** prefix instead of always using **`service`**.
> 
> `_docker_compose_options()` now builds the project name as **`(project_name or service)_asset`**. Leaving **`project_name`** unset keeps the previous behavior for existing subclasses.
> 
> This avoids container/project collisions when different repos run assets that share the same compose **`service`** name (e.g. both testing `"auth"`), without each suite overriding **`_docker_compose_options()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da30d6e7af81d4254650c7a6266f9590ba4739a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->