### PR TITLE
wait_strategy: allow overriding the components wait timeout

### DIFF
--- a/wazo_test_helpers/wait_strategy.py
+++ b/wazo_test_helpers/wait_strategy.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -9,6 +9,8 @@ from collections.abc import Callable
 import requests
 
 from . import until
+
+DEFAULT_TIMEOUT = 10
 
 
 class WaitStrategy:
@@ -26,17 +28,18 @@ class ComponentsWaitStrategy(WaitStrategy, metaclass=ABCMeta):
     def get_status(self, integration_test: Callable[..., None]) -> dict:
         pass
 
-    def __init__(self, components: list[str]):
+    def __init__(self, components: list[str], *, timeout: int = DEFAULT_TIMEOUT):
         self._components = components
+        self._timeout = timeout
 
     def wait(self, integration_test: Callable[..., None]) -> None:
         def components_are_ok(components: list[str]) -> None:
             try:
                 status = self.get_status(integration_test)
             except requests.RequestException as e:
-                assert False, e
+                raise AssertionError(e) from e
 
             for component in components:
                 assert status[component]['status'] == 'ok'
 
-        until.assert_(components_are_ok, self._components, timeout=10)
+        until.assert_(components_are_ok, self._components, timeout=self._timeout)


### PR DESCRIPTION
`ComponentsWaitStrategy.wait` hardcodes a 10s budget and exposes no way to change it:

```python
until.assert_(components_are_ok, self._components, timeout=10)
```

A suite whose services take longer to become ready has no option but to reimplement `wait()` verbatim just to pass a different value. Another PR currently carries exactly that copy, which is what prompted this.

## Change

`timeout` becomes a keyword-only constructor argument defaulting to `DEFAULT_TIMEOUT = 10`, so every existing caller is unaffected.

```python
wait_strategy = ComponentReadyWaitStrategy(('component',), timeout=START_TIMEOUT)
```

Keyword-only because a bare positional number sitting next to the component list reads as anything but a timeout. Note this is the first use of `*` in the package.

It sits on the constructor rather than on `wait()` deliberately. Wait strategies are built once as class attributes next to their component list, and callers reach them through a `ClassVar[WaitStrategy]` typed as the base class — so a per-call `wait(test, timeout=...)` would force the kwarg onto `WaitStrategy.wait` and `NoWaitStrategy.wait`, where a timeout is meaningless. If a per-call override is ever genuinely needed, adding an optional kwarg to `ComponentsWaitStrategy.wait` alone stays additive.

## Drive-by

The `requests.RequestException` branch used `assert False, e`. Asserts are stripped under `python -O`, which would let that branch fall through to `status` being unbound on the next line. It now raises `AssertionError` explicitly, which is also what the other PR copy does — so deleting that copy is a pure win rather than a small regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small test-helper API extension with backward-compatible defaults; behavior change only affects error handling on failed status requests under `-O`.
> 
> **Overview**
> **`ComponentsWaitStrategy`** now accepts an optional keyword-only **`timeout`** (default **`DEFAULT_TIMEOUT` = 10**), passed through to **`until.assert_`** instead of a hardcoded 10 seconds, so integration suites can wait longer for slow components without copying **`wait()`**.
> 
> On **`requests.RequestException`**, the wait loop now **`raise AssertionError(e) from e`** instead of **`assert False, e`**, so failures still surface when Python runs with **`-O`** (asserts removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1e58eff6b2ee5b634555ae15b1bd15257fcd0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->