### PR TITLE
RB-82: release the compose networks when a stack stops

### DIFF
--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -178,21 +178,20 @@ class AbstractAssetLaunchingHelper:
     def rm_networks(cls) -> None:
         """Cleanup project networks to avoid exhausting Docker's address pool."""
         logger.debug('Removing networks...')
-        result = _run_cmd(
+        # `prune` leaves a network that a container still uses, so call it after
+        # the containers stop. `--force` answers the confirmation it would ask.
+        _run_cmd(
             [
                 'docker',
                 'network',
-                'ls',
-                '--quiet',
+                'prune',
+                '--force',
                 '--filter',
                 f'label=com.docker.compose.project={cls._project_name()}',
             ],
             stderr=False,
         )
-        networks = result.stdout.decode('utf-8').split()
-        if networks:
-            _run_cmd(['docker', 'network', 'rm', *networks], stderr=False)
-        logger.debug('Done.')
+        logger.debug('Networks removed')
 
     @classmethod
     def pull_containers(cls) -> None:

--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -159,10 +159,9 @@ class AbstractAssetLaunchingHelper:
             cls.start_containers(bootstrap_container='sync')
         except ContainerStartFailed as e:
             logger.error(e)
-
-            cls.stop_services()
-            cls._maybe_dump_docker_logs()
-            cls._maybe_collect_coverage()
+            # A stack that failed to start needs the same teardown as one that
+            # ran: the caller gets the exception, so nothing else stops it.
+            cls.stop_service_with_asset()
             raise
         logger.debug('Done.')
 

--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -175,6 +175,27 @@ class AbstractAssetLaunchingHelper:
         )
 
     @classmethod
+    @require_container_management
+    def rm_networks(cls) -> None:
+        """Cleanup project networks to avoid exhausting Docker's address pool."""
+        logger.debug('Removing networks...')
+        result = _run_cmd(
+            [
+                'docker',
+                'network',
+                'ls',
+                '--quiet',
+                '--filter',
+                f'label=com.docker.compose.project={cls._project_name()}',
+            ],
+            stderr=False,
+        )
+        networks = result.stdout.decode('utf-8').split()
+        if networks:
+            _run_cmd(['docker', 'network', 'rm', *networks], stderr=False)
+        logger.debug('Done.')
+
+    @classmethod
     def pull_containers(cls) -> None:
         _run_cmd(
             ['docker', 'compose']
@@ -348,6 +369,8 @@ class AbstractAssetLaunchingHelper:
         cls.stop_services()
         cls._maybe_dump_docker_logs()
         cls._maybe_collect_coverage()
+        # Last, because the logs and the coverage need the containers.
+        cls.rm_networks()
         logger.debug('Done.')
 
     @classmethod
@@ -450,13 +473,17 @@ class AbstractAssetLaunchingHelper:
         return result
 
     @classmethod
+    def _project_name(cls) -> str:
+        return (cls.project_name or cls.service) + '_' + cls.asset
+
+    @classmethod
     def _docker_compose_options(cls) -> list[str]:
         root_dir = Path(cls.assets_root)
         options = [
             '--ansi',
             'never',
             '--project-name',
-            (cls.project_name or cls.service) + '_' + cls.asset,
+            cls._project_name(),
             '--file',
             str(root_dir / 'docker-compose.yml'),
             '--file',

--- a/wazo_test_helpers/asset_launching_test_case.py
+++ b/wazo_test_helpers/asset_launching_test_case.py
@@ -159,8 +159,6 @@ class AbstractAssetLaunchingHelper:
             cls.start_containers(bootstrap_container='sync')
         except ContainerStartFailed as e:
             logger.error(e)
-            # A stack that failed to start needs the same teardown as one that
-            # ran: the caller gets the exception, so nothing else stops it.
             cls.stop_service_with_asset()
             raise
         logger.debug('Done.')
@@ -178,8 +176,6 @@ class AbstractAssetLaunchingHelper:
     def rm_networks(cls) -> None:
         """Cleanup project networks to avoid exhausting Docker's address pool."""
         logger.debug('Removing networks...')
-        # `prune` leaves a network that a container still uses, so call it after
-        # the containers stop. `--force` answers the confirmation it would ask.
         _run_cmd(
             [
                 'docker',
@@ -367,7 +363,6 @@ class AbstractAssetLaunchingHelper:
         cls.stop_services()
         cls._maybe_dump_docker_logs()
         cls._maybe_collect_coverage()
-        # Last, because the logs and the coverage need the containers.
         cls.rm_networks()
         logger.debug('Done.')
 


### PR DESCRIPTION
A suite leaks one docker network for each asset it runs. Nothing ever releases
them, so they accumulate until Docker has no address left and every later run
fails to create a network.

## The problem

`stop_service_with_asset` calls `stop_services`, which runs `docker compose
kill` (or `stop` under coverage). Both leave the network of the project
allocated. The only method that releases it is `rm_containers`, and nothing
calls it on the way out: `launch_service_with_asset` calls it on the way **in**,
for the project it is about to start, which never cleans the project that ran
before.

Every project on `pytest_asset` leaks this way. It stays invisible while a suite
uses few assets. wazo-dird uses 24, which is enough to reach the limit of the
default address pool of Docker in one run: after a green run, `docker network
ls` shows 24 networks of the suite, and the next run fails.

## The change

`rm_networks` removes the networks that carry the label
`com.docker.compose.project` of the project, and `stop_service_with_asset` calls
it last, after the dump of the logs and the collection of the coverage, which
both need the containers.

The containers stay. `rm_containers` would release the networks too, but it
removes the containers, and they are what you read to understand a failure.
A container that is stopped holds no endpoint on the network, so the network
goes away and the container stays.

`_project_name` moves to its own method, because the filter needs it. It was
already built inline in `_docker_compose_options`.

The handler of `ContainerStartFailed` no longer repeats that sequence either.
It calls `stop_service_with_asset`, so a launch that fails tears its stack down
the same way, networks included. Nothing else would stop it: the caller only
gets the exception, `_managed_asset` registers its teardown after `setUpClass`
returns, and `unittest` skips `tearDownClass` when `setUpClass` raises.

## Checks

Verified on Docker before writing the change:

- a network whose containers are stopped **can** be removed; `docker network rm`
  only refuses an endpoint that is active. The containers survive, and
  `docker logs` and `docker inspect` still answer.
- compose labels its networks `com.docker.compose.project=<project>`, so the
  filter finds them. Checked against a project named `dird_probeasset`, which
  gave `dird_probeasset_default`.

Measured on the integration suite of wazo-dird, with the same change applied
locally: 569 tests passed in 5 min 51 s, **0 network left** and 84 containers
kept for examination. Before the change the same run left 24 networks.

## Consequence to know

A container that is kept can no longer be started again, because its network is
gone. Reading it — logs, inspect, copy of a file — is unaffected. There is no
command in compose that removes the networks and keeps the containers, so the
filter on the label is the shortest way.

Red bin: RB-82.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-helper teardown only; no production paths, with the trade-off that stopped containers cannot be restarted because their network is removed.
> 
> **Overview**
> Integration asset teardown now **prunes Docker Compose project networks** after stopping containers, so suites that run many assets (e.g. wazo-dird) no longer leak networks until the default address pool is exhausted.
> 
> `stop_service_with_asset` calls new **`rm_networks`**, which runs `docker network prune` filtered by `com.docker.compose.project` matching **`_project_name()`** (extracted from inline compose options). Pruning runs after log dump and coverage collection so containers remain available for debugging; stopped containers are left in place.
> 
> On **`ContainerStartFailed`** during launch, cleanup now delegates to **`stop_service_with_asset`** instead of duplicating stop/logs/coverage without network release—important when `setUpClass` fails and normal teardown does not run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755502339ce10ee9ca7e2908647c0df2f22fcd4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

